### PR TITLE
feat: implement user profile and password update endpoints with security

### DIFF
--- a/src/Controller/User/GetController.php
+++ b/src/Controller/User/GetController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Service\UserService;
+use App\Service\CryptService;
+use App\Enum\EntityType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+
+#[Route('/api/users/{id}', name: 'api_get_user', methods: ['GET'])]
+class GetController extends AbstractController
+{
+    public function __construct(
+        private readonly UserService $userService,
+        private readonly SerializerInterface $serializer,
+        private readonly CryptService $cryptService
+    ) {}
+
+    public function __invoke(string $id): JsonResponse
+    {
+        try {
+            $decryptedId = $this->cryptService->decryptId($id, EntityType::USER->value);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'ID utilisateur invalide'
+            ], 400);
+        }
+
+        try {
+            $user = $this->userService->getUserByEncryptedId($id);
+            $userDTO = $this->userService->toDTO($user);
+
+            return $this->json([
+                'status' => 'success',
+                'data' => json_decode($this->serializer->serialize($userDTO, 'json'), true)
+            ], 200);
+
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage()
+            ], 404);
+        } catch (\Exception $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Une erreur interne est survenue'
+            ], 500);
+        }
+    }
+}

--- a/src/Controller/User/UpdatePasswordController.php
+++ b/src/Controller/User/UpdatePasswordController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\DTO\User\Request\ChangePasswordDTO;
+use App\Service\UserService;
+use App\Service\CryptService;
+use App\Enum\EntityType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/users/{id}/password', name: 'api_update_user_password', methods: ['PUT'])]
+class UpdatePasswordController extends AbstractController
+{
+    public function __construct(
+        private readonly UserService $userService,
+        private readonly SerializerInterface $serializer,
+        private readonly ValidatorInterface $validator,
+        private readonly CryptService $cryptService
+    ) {}
+
+    public function __invoke(Request $request, string $id): JsonResponse
+    {
+        try {
+            $decryptedId = $this->cryptService->decryptId($id, EntityType::USER->value);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'ID utilisateur invalide'
+            ], 400);
+        }
+
+        // Vérifier que l'utilisateur connecté ne peut modifier que son propre mot de passe
+        $currentUser = $this->getUser();
+        if (!$currentUser || $currentUser->getId() !== $decryptedId) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Accès refusé : vous ne pouvez modifier que votre propre mot de passe'
+            ], 403);
+        }
+
+        try {
+            $updatePasswordRequest = $this->serializer->deserialize(
+                $request->getContent(),
+                ChangePasswordDTO::class,
+                'json'
+            );
+        } catch (\Exception $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Le format de la requête est invalide',
+                'errors' => ['Invalid JSON format']
+            ], 400);
+        }
+
+        $errors = $this->validator->validate($updatePasswordRequest);
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Échec de la validation',
+                'errors' => $errorMessages
+            ], 422);
+        }
+
+        try {
+            $this->userService->updatePasswordFromRequest($decryptedId, $updatePasswordRequest);
+
+            return $this->json([
+                'status' => 'success',
+                'message' => 'Mot de passe mis à jour avec succès'
+            ], 200);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage()
+            ], 400);
+        } catch (\Exception $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Erreur serveur lors de la mise à jour du mot de passe'
+            ], 500);
+        }
+    }
+}

--- a/src/Controller/User/UpdateUserController.php
+++ b/src/Controller/User/UpdateUserController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\DTO\User\Request\UpdateUserProfileDTO;
+use App\Service\UserService;
+use App\Service\CryptService;
+use App\Enum\EntityType;
+use App\Validator\UniqueEmail;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/users/{id}', name: 'api_update_user', methods: ['PUT'])]
+class UpdateUserController extends AbstractController
+{
+    public function __construct(
+        private readonly UserService $userService,
+        private readonly SerializerInterface $serializer,
+        private readonly ValidatorInterface $validator,
+        private readonly CryptService $cryptService
+    ) {}
+
+    public function __invoke(Request $request, string $id): JsonResponse
+    {
+        try {
+            $decryptedId = $this->cryptService->decryptId($id, EntityType::USER->value);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'ID utilisateur invalide'
+            ], 400);
+        }
+
+        // Vérifier que l'utilisateur connecté ne peut modifier que son propre profil
+        $currentUser = $this->getUser();
+        if (!$currentUser || $currentUser->getId() !== $decryptedId) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Accès refusé : vous ne pouvez modifier que votre propre profil'
+            ], 403);
+        }
+
+        try {
+            $updateRequest = $this->serializer->deserialize(
+                $request->getContent(),
+                UpdateUserProfileDTO::class,
+                'json'
+            );
+        } catch (\Exception $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Le format de la requête est invalide',
+                'errors' => ['Invalid JSON format']
+            ], 400);
+        }
+
+        $errors = $this->validator->validate($updateRequest);
+        
+        // Validation supplémentaire pour l'unicité de l'email
+        if ($updateRequest->email !== null) {
+            $emailErrors = $this->validator->validate(
+                $updateRequest->email,
+                new UniqueEmail(excludeUserId: $decryptedId)
+            );
+            foreach ($emailErrors as $error) {
+                $errors->add($error);
+            }
+        }
+        
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Échec de la validation',
+                'errors' => $errorMessages
+            ], 422);
+        }
+
+        try {
+            $updatedUser = $this->userService->updateUserFromRequest($decryptedId, $updateRequest);
+            $userDto = $this->userService->toDTO($updatedUser);
+
+            return $this->json([
+                'status' => 'success',
+                'message' => 'Utilisateur mis à jour avec succès',
+                'data' => $userDto
+            ], 200);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage()
+            ], 400);
+        } catch (\Exception $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Erreur serveur lors de la mise à jour de l\'utilisateur'
+            ], 500);
+        }
+    }
+}

--- a/src/DTO/User/Request/ChangePasswordDTO.php
+++ b/src/DTO/User/Request/ChangePasswordDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTO\User\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ChangePasswordDTO
+{
+    #[Assert\NotBlank(message: 'Le mot de passe actuel est requis')]
+    public string $current_password;
+
+    #[Assert\NotBlank(message: 'Le nouveau mot de passe est requis')]
+    #[Assert\Length(
+        min: 8,
+        minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caractères'
+    )]
+    #[Assert\Regex(
+        pattern: '/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/',
+        message: 'Le mot de passe doit contenir au moins une majuscule, une minuscule, un chiffre et un caractère spécial'
+    )]
+    public string $new_password;
+}

--- a/src/DTO/User/Request/UpdateUserProfileDTO.php
+++ b/src/DTO/User/Request/UpdateUserProfileDTO.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\DTO\User\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class UpdateUserProfileDTO
+{
+    #[Assert\NotBlank(message: 'Le nom est requis')]
+    #[Assert\Length(
+        min: 2,
+        max: 255,
+        minMessage: 'Le nom doit contenir au moins {{ limit }} caractères',
+        maxMessage: 'Le nom ne peut pas dépasser {{ limit }} caractères'
+    )]
+    public ?string $name = null;
+
+    #[Assert\NotBlank(message: 'L\'email est requis')]
+    #[Assert\Email(message: 'L\'email {{ value }} n\'est pas valide')]
+    public ?string $email = null;
+
+    #[Assert\Regex(
+        pattern: '/^\+?[0-9\s\-\(\)]{7,}$/',
+        message: 'Le numéro de téléphone n\'est pas valide'
+    )]
+    public ?string $phone = null;
+}

--- a/src/Validator/UniqueEmail.php
+++ b/src/Validator/UniqueEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class UniqueEmail extends Constraint
+{
+    public string $message = 'Cette adresse email est déjà utilisée par un autre utilisateur.';
+    public ?int $excludeUserId = null;
+
+    public function __construct(
+        ?int $excludeUserId = null,
+        ?string $message = null,
+        ?array $groups = null,
+        $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+        
+        $this->excludeUserId = $excludeUserId;
+        $this->message = $message ?? $this->message;
+    }
+}

--- a/src/Validator/UniqueEmailValidator.php
+++ b/src/Validator/UniqueEmailValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Validator;
+
+use App\Repository\UserRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class UniqueEmailValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly UserRepository $userRepository
+    ) {}
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof UniqueEmail) {
+            throw new UnexpectedTypeException($constraint, UniqueEmail::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        $existingUser = $this->userRepository->findOneByEmail($value);
+        
+        if ($existingUser && 
+            ($constraint->excludeUserId === null || $existingUser->getId() !== $constraint->excludeUserId)) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
- Add PUT /api/users/{id} for profile updates (name, email, phone)
- Add PUT /api/users/{id}/password for password changes
- Add GET /api/users/{id} for user profile retrieval
- Create UpdateUserProfileDTO and ChangePasswordDTO with validation
- Implement encrypted ID handling and email uniqueness validation
- Add authorization checks to restrict users to their own profiles
- Follow SOLID principles and maintain consistent JSON responses